### PR TITLE
Updating redis.conf.jinja to redis v2.8.5

### DIFF
--- a/redis/files/redis.conf.jinja
+++ b/redis/files/redis.conf.jinja
@@ -6,9 +6,18 @@ daemonize yes
 pidfile {{ redis.get('pidfile', '/var/db/redis/redis.pid') }}
 port {{ redis.get('port', 6379) }}
 
+tcp-backlog {{ redis.get('tcp-backlog', 511) }}
+
 {% if redis['bind'] is defined %}
 bind {{ redis['bind'] }}
 {% endif -%}
+
+{% if redis['unixsocket'] is defined %}
+unixsocket {{ redis['unixsocket'] }}
+unixsocketperm {{ redis.get('unixsocketperm', 755) }}
+{% endif -%}
+
+tcp-keepalive {{ redis.get('tcp-keepalive', 0) }}
 
 loglevel {{ redis.get('loglevel', 'notice') }}
 logfile {{ redis.get('logfile', '/var/log/redis/redis.log') }}
@@ -31,14 +40,65 @@ save 300 10
 save 60 10000
 {% endif -%}
 
+stop-writes-on-bgsave-error {{ redis.get('stop-writes-on-bgsave-error', 'yes') }}
+
 rdbcompression {{ redis.get('rdbcompression', 'yes') }}
+rdbchecksum {{ redis.get('rdbchecksum', 'yes') }}
+
 dbfilename {{ redis.get('dbfilename', 'dump.rdb') }}
 dir {{ redis.get('root_dir', '/var/db/redis') }}
 
+{% if redis['slaveof'] is defined %}
+slaveof {{ redis['slaveof']['masterip'] }} {{ redis['slaveof']['masterport'] }}
+{% endif -%}
+
+{% if redis['masterauth'] is defined %}
+masterauth {{ redis['masterauth'] }}
+{% endif -%}
+
 slave-serve-stale-data {{ redis.get('slave-serve-state-data', 'yes') }}
+slave-read-only {{ redis.get('slave-read-only', 'yes') }}
+
+{% if redis['repl-ping-slave-period'] is defined %}
+repl-ping-slave-period {{ redis['repl-ping-slave-period'] }}
+{% endif -%}
+
+{% if redis['repl-timeout'] is defined %}
+repl-timeout {{ redis['repl-timeout'] }}
+{% endif -%}
+
+repl-disable-tcp-nodelay {{ redis.get('repl-disable-tcp-nodelay', 'no') }}
+
+{% if redis['repl-backlog-size'] is defined %}
+repl-backlog-size {{ redis['repl-backlog-size'] }}
+{% endif -%}
+
+{% if redis['repl-backlog-ttl'] is defined %}
+repl-backlog-ttl {{ redis['repl-backlog-ttl'] }}
+{% endif -%}
+
+slave-priority {{ redis.get('slave-priority', 100) }}
+
+{% if redis['min-slaves-to-write'] is defined %}
+requiremin-slaves-to-write {{ redis['min-slaves-to-write'] }}
+{% endif -%}
+
+{% if redis['min-slaves-max-lag'] is defined %}
+requiremin-slaves-max-lag {{ redis['min-slaves-max-lag'] }}
+{% endif -%}
 
 {% if redis['pass'] is defined %}
 requirepass {{ redis['pass'] }}
+{% endif -%}
+
+{% if redis['rename-command'] is defined %}
+{% for k, v in redis['rename-command'] %}
+rename-command {{ k }} {{ v }}
+{% endfor %}
+{% endif -%}
+
+{% if redis['maxclients'] is defined %}
+requiremaxclients {{ redis['maxclients'] }}
 {% endif -%}
 
 maxmemory {{ redis.get('maxmemory', 8053063680) }}
@@ -46,6 +106,7 @@ maxmemory-policy {{ redis.get('maxmemory-policy', 'volatile-lru') }}
 maxmemory-samples {{ redis.get('maxmemory-samples', 3) }}
 
 appendonly {{ redis.get('appendonly', 'no') }}
+appendfilename {{ redis.get('appendfilename', 'appendonly.aof') }}
 appendfsync {{ redis.get('appendfsync', 'everysec') }}
 
 no-appendfsync-on-rewrite {{ redis.get('no-appendfsync-on-rewrite', 'no') }}
@@ -53,18 +114,17 @@ auto-aof-rewrite-percentage {{ redis.get('auto-aof-rewrite-percentage', 100) }}
 
 auto-aof-rewrite-min-size {{ redis.get('auto-aof-rewrite-min-size', '64mb') }}
 
+lua-time-limit {{ redis.get('lua-time-limit', 5000) }}
+
 slowlog-log-slower-than {{ redis.get('slowlog-log-slower-than', 10000) }}
+slowlog-max-len {{ redis.get('slowlog-max-len', 128) }}
 
-slowlog-max-len {{ redis.get('slowlog-max-len', 1024) }}
-
-vm-enabled {{ vm.get('enabled', 'no') }}
-vm-swap-file {{ vm.get('swap-file', '/tmp/redis.swap') }}
-vm-max-memory {{ vm.get('max-memory', 0) }}
-vm-page-size {{ vm.get('page-size', 32) }}
-vm-pages {{ vm.get('pages', 134217728) }}
-vm-max-threads {{ vm.get('max-threads', 4) }}
+notify-keyspace-events {{ redis.get('notify-keyspace-events', '""') }}
 
 ############################### ADVANCED CONFIG ###############################
+
+hash-max-ziplist-entries 512
+hash-max-ziplist-value 64
 
 list-max-ziplist-entries 512
 list-max-ziplist-value 64
@@ -75,3 +135,11 @@ zset-max-ziplist-entries 128
 zset-max-ziplist-value 64
 
 activerehashing yes
+
+client-output-buffer-limit normal 0 0 0
+client-output-buffer-limit slave 256mb 64mb 60
+client-output-buffer-limit pubsub 32mb 8mb 60
+
+hz 10
+
+aof-rewrite-incremental-fsync yes


### PR DESCRIPTION
I tried to use the redis formula today, but was presented with the following error in /var/log/upstart/redis-server.log: 

```
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 38
>>> 'vm-enabled no'
Bad directive or wrong number of arguments
```

The current stable version of redis is v2.8.5. According to the documentation it appears that redis v2.4 was the last version of redis to support virtual memory, and redis v.2.8.5 chokes on config options related to virtual memory.(http://redis.io/topics/virtual-memory)

I removed the configuration options related to vm and added the other options that existed in the v2.8.5 config that were not in redis.config.jinja.
