### PR TITLE
Fix error when run without install_from in pillar

### DIFF
--- a/redis/common.sls
+++ b/redis/common.sls
@@ -1,7 +1,7 @@
 {% set redis = pillar.get('redis', {}) -%}
 {% set install_from = redis.get('install_from', 'source') -%}
 
-{% if redis['install_from'] == 'source' %}
+{% if install_from == 'source' %}
 {% set version = redis.get('version', 'stable') -%}
 {% set checksum = redis.get('checksum', 'sha1=12755897666792eb9e1a0b7e4589eb1cb8e229d0') -%}
 {% set root = redis.get('root', '/usr/local') -%}
@@ -37,7 +37,7 @@ make-redis:
     - watch:
       - cmd: get-redis
 
-{% elif redis['install_from'] == 'package' %}
+{% elif install_from == 'package' %}
 {% set version = redis.get('version', None) -%}
 
 install-redis:


### PR DESCRIPTION
If install_from is not set, this state will fail to compile.
