### PR TITLE
allow redis version to be specified by number 

### DIFF
--- a/redis/common.sls
+++ b/redis/common.sls
@@ -3,7 +3,7 @@
 
 {% if install_from == 'source' %}
 {% set version = redis.get('version', '2.8.8') -%}
-{% set checksum = redis.get('checksum', 'sha1=d944c90d87e4cf2f382506c3e155335dd31da82e') -%}
+{% set checksum = redis.get('checksum', 'sha1=aa811f399db58c92c8ec5e48271d307e9ab8eb81') -%}
 {% set root = redis.get('root', '/usr/local') -%}
 
 redis-dependencies:


### PR DESCRIPTION
Default values for redis versions were specified by stable, beta, old.  and downloaded by http://download.redis.io/redis-{{ version }}.tar.gz.  The problem is that the "stable" version is a moving target that changes with every release, and because of this the default checksum does not match the stable version.

It would be better to specify the exact version of redis that the user wants to install, and default to the checksum for that version.  Releases can be downloaded by version at http://download.redis.io/releases/redis-{{ version }}.tar.gz.

Thus the defaults in the formula will always work because the version and checksum are pinned to each other.

Thank you!
