### PR TITLE
Remove tcp-backlog directive from 2.6 conf

### DIFF
--- a/redis/files/redis-2.6.conf.jinja
+++ b/redis/files/redis-2.6.conf.jinja
@@ -6,8 +6,6 @@ daemonize yes
 pidfile {{ redis.get('pidfile', '/var/db/redis/redis.pid') }}
 port {{ redis.get('port', 6379) }}
 
-tcp-backlog {{ redis.get('tcp-backlog', 511) }}
-
 {% if redis['bind'] is defined %}
 bind {{ redis['bind'] }}
 {% endif -%}


### PR DESCRIPTION
tcp-backlog (and backlog before it) directive wasn't introduced until 2.8. See these commits antirez/redis@8dda9dbe and antirez/redis@917b85149.
