### PR TITLE
Restart redis service if dependencies change

### DIFF
--- a/redis/server.sls
+++ b/redis/server.sls
@@ -90,7 +90,7 @@ redis-server:
       - file: redis-pid-dir
   service:
     - running
-    - require:
+    - watch:
       - file: redis-init-script
       - cmd: redis-old-init-disable
       - file: redis-server


### PR DESCRIPTION
Change require to watch in redis-server service, so it gets restarted eg when config file changes.
