### PR TITLE
Fix pillar example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -1,4 +1,4 @@
 redis:
-  home: /var/lib/redis
+  root_dir: /var/lib/redis
   user: redis
-  port: 6777
+  port: 6397


### PR DESCRIPTION
- `home` is unused, this is `root_dir` according to the template
- Use the default Redis port, by default.
