### PR TITLE
adding cfg-version divide for several debian versions

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -3,7 +3,11 @@
         'pkg_name': 'redis-server',
         'svc_name': 'redis-server',
         'cfg_name': '/etc/redis/redis.conf',
-        'cfg_version': '2.8',
+        'cfg_version': salt['grains.filter_by']({
+	  'wheezy': '2.4',
+	  'jessie': '2.8',
+	  'default': '2.8'
+	}, grain='oscodename'),
     },
     'RedHat': {
         'pkg_name': 'redis',


### PR DESCRIPTION
As in debian wheezy the standard package version of redis is still 2.4, I added this  so the right config version is used by default.