### PR TITLE
repaired redis-2.4.conf.jinja

### DIFF
--- a/redis/files/redis-2.4.conf.jinja
+++ b/redis/files/redis-2.4.conf.jinja
@@ -1,5 +1,5 @@
 # Redis configuration file 
-{% from "redis/map.jinja" import redis with context %}
+{% set redis  = pillar.get('redis', {}) -%}
 
 # Note on units: when memory size is needed, it is possible to specifiy
 # it in the usual form of 1k 5GB 4M and so forth:


### PR DESCRIPTION
let redis-2.4.conf get its data from the pillar so it can be used again with

the pillar.example