### PR TITLE
Optional max memory

### DIFF
--- a/redis/files/redis-2.6.conf.jinja
+++ b/redis/files/redis-2.6.conf.jinja
@@ -104,9 +104,11 @@ rename-command {{ k }} {{ v }}
 requiremaxclients {{ redis_settings.maxclients }}
 {% endif -%}
 
+{% if redis_settings.maxmemory is defined %}
 maxmemory {{ redis_settings.maxmemory|default(8053063680) }}
 maxmemory-policy {{ redis_settings.maxmemory_policy|default('volatile-lru') }}
 maxmemory-samples {{ redis_settings.maxmemory_samples|default(3) }}
+{% endif %}
 
 appendonly {{ redis_settings.appendonly }}
 appendfilename {{ redis_settings.appendfilename }}

--- a/redis/files/redis-2.6.conf.jinja
+++ b/redis/files/redis-2.6.conf.jinja
@@ -105,9 +105,9 @@ requiremaxclients {{ redis_settings.maxclients }}
 {% endif -%}
 
 {% if redis_settings.maxmemory is defined %}
-maxmemory {{ redis_settings.maxmemory|default(8053063680) }}
-maxmemory-policy {{ redis_settings.maxmemory_policy|default('volatile-lru') }}
-maxmemory-samples {{ redis_settings.maxmemory_samples|default(3) }}
+maxmemory {{ redis_settings.maxmemory }}
+maxmemory-policy {{ redis_settings.maxmemory_policy }}
+maxmemory-samples {{ redis_settings.maxmemory_samples }}
 {% endif %}
 
 appendonly {{ redis_settings.appendonly }}

--- a/redis/files/redis-2.8.conf.jinja
+++ b/redis/files/redis-2.8.conf.jinja
@@ -107,8 +107,8 @@ requiremaxclients {{ redis_settings.maxclients }}
 
 {% if redis_settings.maxmemory is defined %}
 maxmemory {{ redis_settings.maxmemory }}
-maxmemory-policy {{ redis_settings.maxmemory_policy|default('volatile-lru') }}
-maxmemory-samples {{ redis_settings.maxmemory-samples|default(3) }}
+maxmemory-policy {{ redis_settings.maxmemory_policy }}
+maxmemory-samples {{ redis_settings.maxmemory_samples }}
 {% endif %}
 
 appendonly {{ redis_settings.appendonly }}

--- a/redis/files/redis-2.8.conf.jinja
+++ b/redis/files/redis-2.8.conf.jinja
@@ -105,9 +105,11 @@ rename-command {{ k }} {{ v }}
 requiremaxclients {{ redis_settings.maxclients }}
 {% endif -%}
 
-maxmemory {{ redis_settings.maxmemory|default(8053063680) }}
+{% if redis_settings.maxmemory is defined %}
+maxmemory {{ redis_settings.maxmemory }}
 maxmemory-policy {{ redis_settings.maxmemory_policy|default('volatile-lru') }}
-maxmemory-samples {{ redis_settings.maxmemory_samples|default(3) }}
+maxmemory-samples {{ redis_settings.maxmemory-samples|default(3) }}
+{% endif %}
 
 appendonly {{ redis_settings.appendonly }}
 appendfilename {{ redis_settings.appendfilename }}

--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -38,6 +38,8 @@
         'install_from': 'package',
         'loglevel': 'notice',
         'lua_time_limit': 5000,
+        'maxmemory_policy': 'volatile-lru',
+        'maxmemory_samples': 3,
         'notify_keyspace_events': '""',
         'no_appendfsync_on_rewrite': 'no',
         'port': 6379,


### PR DESCRIPTION
Ok this is a more controversial pr. In redis maxmemory is set to 0 by default, so there is no memory limitation. in the  2.6|8-config-template maxmemory ist set to 8053063680(7.5 GB?).
I don't unterstand why it's set to this magical value, so I made it optional in this pull request.
I'm not really sure if there is cause for this 7.5 GB, I can't see it.