### PR TITLE
change pidfile default for debian

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -9,7 +9,7 @@
 	  'default': '2.8'
 	}, grain='oscodename'),
 	'logfile': '/var/log/redis/redis-server.log',
-        'pidfile': '/var/run/redis-server.pid'
+        'pidfile': '/var/run/redis/redis-server.pid'
     },
     'RedHat': {
         'pkg_name': 'redis',


### PR DESCRIPTION
The default pidfile value for debian was just wrong.