### PR TITLE
tcp_backlog breaks on redis 2.8 and thus should not be configured by default

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -63,7 +63,6 @@
         'stop_writes_on_bgsave_error': 'yes',
         'svc_onboot': True,
         'svc_state': 'running',
-        'tcp_backlog': 511,
         'tcp_keepalive': 0,
         'unixsocketperm': 755,
         'user': 'redis'


### PR DESCRIPTION
with the shipped redis-server on ubuntu LTS 14.04 setting tcp-backlog leads to following behaviour

```
root@ip-10-1-9-129:/home/ubuntu# /etc/init.d/redis-server restart
Stopping redis-server: redis-server.
Starting redis-server: 
*** FATAL CONFIG FILE ERROR ***
Reading the configuration file, at line 11
>>> 'tcp-backlog 511'
Bad directive or wrong number of arguments
failed
```

there is no way to remove the default value once set/set it to undefined from the pillar and thus I think it should be removed from the default_settings.
