### PR TITLE
Updated pillar example

### DIFF
--- a/pillar.example
+++ b/pillar.example
@@ -9,7 +9,7 @@ redis:
     - '60  10000'
 
   lookup:
-    svc_state: stopped
+    svc_state: running
     cfg_name: /etc/redis.conf
     pkg_name: redis-server
     svc_name: redis-server


### PR DESCRIPTION
Setting svc_state: stopped make tests and formula fail.

See this

```
local:
----------
          ID: install-redis
    Function: pkg.installed
        Name: redis-server
      Result: True
     Comment: Package redis-server is already installed
     Started: 18:35:39.180285
    Duration: 453.081 ms
     Changes:   
----------
          ID: redis_config
    Function: file.managed
        Name: /etc/redis.conf
      Result: True
     Comment: File /etc/redis.conf is in the correct state
     Started: 18:35:39.635258
    Duration: 37.347 ms
     Changes:   
----------
          ID: redis_service
    Function: service.stopped
        Name: redis-server
      Result: False
     Comment: State 'service.stopped' was not found in SLS 'redis.server'
              Reason: 'service.stopped' is not available.
     Started: 
    Duration: 
     Changes:   

Summary for local
------------
Succeeded: 2
Failed:    1
------------
Total states run:     3
Total run time: 490.428 ms
```