### PR TITLE
two minor updates for arch linux

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -29,7 +29,8 @@
         'cfg_name': '/etc/redis.conf',
         'cfg_version': '3.0',
         'logfile': '/var/log/redis/redis.log',
-        'pidfile': '/var/run/redis.pid'
+        'pidfile': '/var/run/redis.pid',
+        'daemonize': 'no'
     },
 }, merge=salt['pillar.get']('redis:lookup')) %}
 

--- a/redis/server.sls
+++ b/redis/server.sls
@@ -88,6 +88,17 @@ redis-server:
 
 {% else %}
 
+{% if grains['os_family'] == 'Arch' %}
+{% set user           = redis_settings.user -%}
+{% set group          = redis_settings.group -%}
+redis-log-dir:
+  file.directory:
+    - name: /var/log/redis
+    - mode: 755
+    - user: {{ user }}
+    - group: {{ group }}
+    - makedirs: True
+{% endif %}
 
 redis_config:
   file.managed:


### PR DESCRIPTION
two minor updates for arch linux:

- daemonize should be set to false, so it works nicely with the default systemd configuration

- logdirectory is not created by default from package manager, so we need to create it