### PR TITLE
tcp_backlog

### DIFF
--- a/redis/files/redis-2.8.conf.jinja
+++ b/redis/files/redis-2.8.conf.jinja
@@ -14,9 +14,7 @@ unixsocket {{ redis_settings.unixsocket }}
 unixsocketperm {{ redis_settings.unixsocketperm }}
 {% endif -%}
 
-{% if redis_settings.tcp_backlog is defined and redis_settings.tcp_backlog > 0 %}
-tcp-backlog {{ redis_settings.tcp_backlog }}
-{% endif -%}
+timeout 0
 tcp-keepalive {{ redis_settings.tcp_keepalive }}
 
 loglevel {{ redis_settings.loglevel }}


### PR DESCRIPTION
This is a fix I required to get redis working on **Ubuntu 14.04.4 LTS**.

I added `tcp_backlog: -1` to pillar, it ignored it.

This PR will be probably be rejected, but it's an indication of a problem.