### PR TITLE
Fixed multiple condition error in common.sls

### DIFF
--- a/redis/common.sls
+++ b/redis/common.sls
@@ -18,7 +18,7 @@ redis-dependencies:
         - python-devel
         - make
         - libxml2-devel
-    {% elif grains['os_family'] == 'Debian' or 'Ubuntu' %}
+    {% elif grains['os_family'] == 'Debian' or grains['os_family'] == 'Ubuntu' %}
         - build-essential
         - python-dev
         - libxml2-dev


### PR DESCRIPTION
There is a problem in `common.sls` that always goes into the `elif` branch if the value of `grains['os_family']` is not `'RedHat'`. Thus, I fixed the condition in `common.sls`.