### PR TITLE
Configure default root dir for FreeBSD

### DIFF
--- a/redis/osfamilymap.yaml
+++ b/redis/osfamilymap.yaml
@@ -42,4 +42,5 @@ FreeBSD:
   logfile: /var/log/redis/redis.log
   pidfile: /var/run/redis.pid
   overcommit_memory: False
+  root_dir: /var/db/redis
 


### PR DESCRIPTION
In FreeBSD root dir is /var/db/redis instead of /var/lib/redis