### PR TITLE
Fix Freebsd pidfile path

### DIFF
--- a/redis/osfamilymap.yaml
+++ b/redis/osfamilymap.yaml
@@ -40,7 +40,7 @@ FreeBSD:
   cfg_name: /usr/local/etc/redis.conf
   cfg_version: '3.0'
   logfile: /var/log/redis/redis.log
-  pidfile: /var/run/redis.pid
+  pidfile: /var/run/redis/redis.pid
   overcommit_memory: False
   root_dir: /var/db/redis
 


### PR DESCRIPTION
According to FreeBSD package system [1][2] the correct path for pidfile is `/var/run/redis/redis.pid`

[1] https://github.com/freebsd/freebsd-ports/blob/master/databases/redis/Makefile#L70
[2] https://github.com/freebsd/freebsd-ports/blob/master/databases/redis/files/redis.in#L29