### PR TITLE
Fix `redis:lookup` regression (fixes #75)

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -5,16 +5,17 @@
 {% import_yaml 'redis/osfamilymap.yaml' as osfamilymap %}
 {% import_yaml 'redis/osfingermap.yaml' as osfingermap %}
 
-{% set redis_settings = salt['grains.filter_by'](
-    defaults,
-    merge = salt['grains.filter_by'](
-        osfamilymap,
-        grain='os_family',
-        merge = salt['grains.filter_by'](
-            osfingermap,
-            grain='osfinger',
-            merge = salt['pillar.get']('redis', {}),
-        ),
-    ),
-    base='redis')
-%}
+{# merge the osfamilymap #}
+{% set osfamily = salt['grains.filter_by'](osfamilymap, grain='os_family') or{} %}
+{% do salt['defaults.merge'](defaults['redis'], osfamily) %}
+
+{# merge the osfingermap #}
+{% set osfinger = salt['grains.filter_by'](osfingermap, grain='osfinger') or {} %}
+{% do salt['defaults.merge'](defaults['redis'], osfinger) %}
+
+{# merge the lookup #}
+{% set lookup = salt['pillar.get']('redis:lookup', default={}, merge=True) %}
+{% do salt['defaults.merge'](defaults['redis'], lookup) %}
+
+{# merge all #}
+{% set redis_settings = salt['pillar.get']('redis', default=defaults['redis'], merge=True) %}


### PR DESCRIPTION
I've already been submitting `map.jinja` PRs today:

* https://github.com/saltstack-formulas/apache-formula/pull/252
* https://github.com/saltstack-formulas/salt-formula/pull/396

Noticed issue #75 here was effectively the same issue re: `lookup` issues:

> The issue here is that the `lookup` isn't being currently being merged in [`map.jinja`](https://github.com/saltstack-formulas/redis-formula/blob/ad145b675a913aa576df2265a92e074008ac68b3/redis/map.jinja).

The structure of this fix has been discussed in detail, particularly in the `apache-formula` pull.

---

I've tested before and after this PR, with the following `lookup` values, almost identical to `pillar.example` except for `overcommit_memory`, in order to test for #75:

```yaml
  lookup:
    svc_state: running
    cfg_name: /etc/redis.conf
    pkg_name: redis-server
    svc_name: redis-server
    overcommit_memory: False
```

The diff of `map.jinja` rendering before and after this PR:

```diff
--- ad145b6 (before PR)
+++ 8b31c2c (after PR)
@@ -7,7 +7,7 @@
   "auto_aof_rewrite_percentage": 100,
   "bin": "/usr/local/bin/redis-server",
   "bind": "127.0.0.1",
-  "cfg_name": "/etc/redis/redis.conf",
+  "cfg_name": "/etc/redis.conf",
   "cfg_version": "3.2",
   "daemonize": "yes",
   "database_count": 16,
@@ -31,7 +31,7 @@
   "maxmemory_samples": 3,
   "no_appendfsync_on_rewrite": "no",
   "notify_keyspace_events": "",
-  "overcommit_memory": true,
+  "overcommit_memory": false,
   "pidfile": "/var/run/redis/redis-server.pid",
   "pkg_name": "redis-server",
   "port": 6379,
```

* The same mapping is produced as before, now with the `lookup` being merged in as well.