### PR TITLE
fix(map): avoid `defaults.merge` bug on `salt-ssh` (`redis_settings`)

### DIFF
--- a/redis/map.jinja
+++ b/redis/map.jinja
@@ -16,4 +16,4 @@
 ) %}
 
 {#- Merge the redis pillar #}
-{%- set redis = salt['pillar.get']('redis', default=defaults, merge=True) %}
+{%- set redis_settings = salt['pillar.get']('redis', default=defaults, merge=True) %}


### PR DESCRIPTION
* fix #77