### PR TITLE
feat(arch): add support for archlinux & log/service vars

### DIFF
--- a/redis/common.sls
+++ b/redis/common.sls
@@ -38,7 +38,6 @@ get-redis:
     - watch:
       - file: get-redis
 
-
 make-and-install-redis:
   cmd.wait:
     - cwd: {{ root }}/redis-{{ version }}
@@ -70,10 +69,9 @@ install-redis:
     - version: {{ redis_settings.version }}
     - ignore_epoch: True
     {% endif %}
+{% endif %}
 
-    {%- if grains.os_family|lower == 'suse' %}
-        {# this is basically a workaround for faulty packaging #}
-install-redis-log:
+install-redis-user-group:
   group.present:
     - name: {{ redis_settings.group }}
   user.present:
@@ -81,9 +79,13 @@ install-redis-log:
     - gid_from_name: True
     - home: {{ redis_settings.home }}
     - require:
-      - group: install-redis-log
+      - group: install-redis-user-group
+    - require_in:
+      - file: install-redis-log-dir
+
+install-redis-log-dir:
   file.directory:
-    - name: /var/log/redis
+    - name: {{ redis_settings.dir.log }}
     - mode: 755
     - user: {{ redis_settings.user }}
     - group: {{ redis_settings.group }}
@@ -92,18 +94,14 @@ install-redis-log:
         - group
         - mode
     - makedirs: True
-    - require:
-      - user: install-redis-log
 
 install-redis-service:
   file.replace:
-    - name: /usr/lib/systemd/system/redis@.service
+    - name: {{ redis_settings.dir.service }}/{{ redis_settings.svc_name }}
     - pattern: ^Type=notify
     - repl: Type=simple
+    - onlyif: test -f {{ redis_settings.dir.service }}/{{ redis_settings.svc_name }}
   cmd.run:
     - name: systemctl daemon-reload
-    - require:
-      - file: install-redis-log
-    {% endif %}
-
-{% endif %}
+    - onchanges:
+      - file: install-redis-log-dir

--- a/redis/defaults.yaml
+++ b/redis/defaults.yaml
@@ -73,7 +73,7 @@ redis:
 
   retry_option:
     # https://docs.saltstack.com/en/latest/ref/states/requisites.html#retrying-states
-    attempts: 3
+    attempts: 2
     until: true
     interval: 60
     splay: 10

--- a/redis/defaults.yaml
+++ b/redis/defaults.yaml
@@ -11,6 +11,9 @@ redis:
       dbfilename: dump-{name}.rdb
       svc_state: running
       svc_onboot: true
+  dir:
+    log: /var/log/redis
+    service: /lib/systemd/system
   appendfilename: appendonly.aof
   appendonly: 'no'
   appendfsync: everysec
@@ -52,6 +55,7 @@ redis:
     - '60 10000'
   stop_writes_on_bgsave_error: 'yes'
   svc_onboot: true
+  svc_name: redis
   svc_state: running
   timeout: 0
   tcp_backlog: 511

--- a/redis/instances.sls
+++ b/redis/instances.sls
@@ -10,7 +10,7 @@ include:
 
 redis_systemd_template:
   file.managed:
-  - name: /lib/systemd/system/redis-server@.service
+  - name: {{ redis_settings.dir.service }}/redis-server@.service
   - replace: False
   - source: salt://redis/files/redis-server@.service
 

--- a/redis/osfamilymap.yaml
+++ b/redis/osfamilymap.yaml
@@ -14,7 +14,6 @@ Debian:
 RedHat:
   pkg_name: redis
   python_dev_package: python-devel
-  svc_name: redis
   cfg_name: /etc/redis.conf
   cfg_version: '3.0'
   logfile: /var/log/redis/redis.log
@@ -27,7 +26,6 @@ RedHat:
     pidfile: /var/run/redis/sentinel.pid
 Arch:
   pkg_name: redis
-  svc_name: redis
   cfg_name: /etc/redis.conf
   cfg_version: '3.0'
   logfile: /var/log/redis/redis.log
@@ -35,7 +33,6 @@ Arch:
   daemonize: 'no'
 FreeBSD:
   pkg_name: redis
-  svc_name: redis
   cfg_name: /usr/local/etc/redis.conf
   cfg_version: '3.0'
   logfile: /var/log/redis/redis.log
@@ -56,4 +53,3 @@ Suse:
   sentinel:
     pidfile: /var/run/redis/sentinel.pid
   disable_transparent_huge_pages: true
-  systemd_type: simple

--- a/redis/server/clean.sls
+++ b/redis/server/clean.sls
@@ -29,10 +29,8 @@ redis-server-clean:
       - /etc/init.d/redis
       - {{ r.root|default('/usr/local') }}
       - /etc/redis
-      - /var/log/redis
-      - /var/lib/redis
-      - /usr/lib/systemd/system/redis*
-      - /lib/systemd/system/redis*
+      - {{ r.dir.log }}
+      - {{ r.dir.service }}/redis*
       - /var/run/redis
       - /var/run/redis_6379.pid
 

--- a/redis/server/install.sls
+++ b/redis/server/install.sls
@@ -77,6 +77,21 @@ redis_disable_transparent_huge_pages:
         - name: echo "never" > /sys/kernel/mm/transparent_hugepage/enabled
     {%- endif %}
 
+    {%- if grains.os_family|lower == 'arch' %}
+redis_service_simple:
+  file.replace:
+    - name: {{ r.dir.service }}/redis.service
+    - pattern: Type=notify
+    - repl: Type=simple
+    - onlyif: test -f {{ r.dir.service }}/redis.service
+    - require_in:
+      - service: redis_service
+  cmd.run:
+    - name: systemctl daemon-reload
+    - onchanges:
+      - file: redis_service_simple
+    {%- endif %}
+
 redis_service:
   service.{{ r.svc_state }}:
     {% if r.install_from in ('source', 'archive') %}


### PR DESCRIPTION


### PR progress checklist (to be filled in by reviewers)
<!-- Please leave this checklist for reviewers to tick as they work through the PR. -->

- [x] Changes to documentation are appropriate (or tick if not required)
- [x] Changes to tests are appropriate (or tick if not required)
- [ ] Reviews completed

---

### What type of PR is this?
<!-- Please tick each box that is relevant (after creating the PR). -->

#### Primary type
<!-- There really should be only *one* of these types ticked for each PR. -->

- [ ] `[build]`    Changes related to the build system
- [ ] `[chore]`    Changes to the build process or auxiliary tools and libraries such as documentation generation
- [ ] `[ci]`       Changes to the continuous integration configuration
- [ ] `[feat]`     A new feature
- [x] `[fix]`      A bug fix
- [ ] `[perf]`     A code change that improves performance
- [x] `[refactor]` A code change that neither fixes a bug nor adds a feature
- [ ] `[revert]`   A change used to revert a previous commit
- [ ] `[style]`    Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc.)

#### Secondary type
<!-- Most PRs should include all of the following types as well. -->

- [ ] `[docs]`     Documentation changes
- [ ] `[test]`     Adding missing or correcting existing tests

### Does this PR introduce a `BREAKING CHANGE`?
<!-- If so, change the following to a `Yes` and explain what the breaking changes are. -->
<!-- If there are multiple breaking changes, list them all. -->

No.

### Related issues and/or pull requests
<!-- Please link any related issues/PRs here, especially any issues that are closed by this PR. -->

The formula does not support Archlinux and does not ensure log-dir and systemd-file is correct across all OS.
```
          ID: redis_service
    Function: service.running
        Name: redis
      Result: False
     Comment: Attempt 1: Returned a result of "False", with the following comment: "Job for redis.service failed because a timeout was exceeded.
              See "systemctl status redis.service" and "journalctl -xe" for details."
              Attempt 2: Returned a result of "False", with the following comment: "Job for redis.service failed because a timeout was exceeded.
              See "systemctl status redis.service" and "journalctl -xe" for details."
              Job for redis.service failed because a timeout was exceeded.
              See "systemctl status redis.service" and "journalctl -xe" for details.
     Started: 12:44:03.065380
    Duration: 307713.744 ms
     Changes:
```


### Describe the changes you're proposing
<!-- A clear and concise description of what you have implemented. -->
<!-- Consider explaining each commit if they cover different aspects of the proposed changes. -->

Ensure user, group, log-directory exist because the package state does not do everything (i.e. Arch, Suse) and archive state does none of these things.  Those states should always run. This PR fixes that.

### Pillar / config required to test the proposed changes
<!-- Provide links to the SLS files and/or relevant configs (be sure to remove sensitive info). -->



### Debug log showing how the proposed changes work
<!-- Include a debug log showing how these changes work, e.g. using `salt-minion -l debug`. -->
<!-- Alternatively, linking to Kitchen debug logs is useful, e.g. via. Travis CI. -->
<!-- Most useful is providing a passing InSpec test, which can be used to verify any proposed changes. -->



### Documentation checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Updated the `README` (e.g. `Available states`).
- [ ] Updated `pillar.example`.

### Testing checklist
<!-- Please tick each box that is relevant (after creating the PR). -->

- [ ] Included in Kitchen (i.e. under `state_top`).
- [x] Covered by new/existing tests (e.g. InSpec, Serverspec, etc.).
- [ ] Updated the relevant test pillar.

### Additional context
<!-- Add any other context about the proposed changes here. -->


